### PR TITLE
[WIP] Fix MarkerIcon anchor

### DIFF
--- a/documents/markericon/README.md
+++ b/documents/markericon/README.md
@@ -1,6 +1,8 @@
-# MarkerIcon interface
+# MarkerIcon Interface
 
-**[usage 1]SimpleIcon**
+## Usage Examples
+
+### Simple Icon
 
 ```typescript
 let icon: MarkerIcon = {
@@ -21,7 +23,7 @@ this.map.addMarker({
 
 ![](./simpleicon.png)
 
-**[usage 2]Color Icon**
+### Color Icon
 
 ```typescript
 this.map.addMarker({
@@ -34,7 +36,7 @@ this.map.addMarker({
 
 ![](./marker_icon-color.png)
 
-**[usage 3]Base64 Encoded Icon**
+### Base64 Encoded Icon
 
 ```typescript
 let icon: string = "data:image/png;base64,iVBORw0KGgo...CC";
@@ -65,7 +67,7 @@ img.onload = () => {
 
 ![](./base64-icon.gif)
 
-## Interface members
+## Interface Members
 
 <table>
 <tr>
@@ -84,6 +86,14 @@ img.onload = () => {
 &nbsp;&nbsp;width: number,<br>
 &nbsp;&nbsp;height: number,<br>
 }</td>
-  <td>(optional) size of the icon image</td>
+  <td>(optional) Size of the icon image.</td>
+</tr>
+<tr>
+  <td>anchor</td>
+  <td>{<br>
+&nbsp;&nbsp;x: number,<br>
+&nbsp;&nbsp;y: number,<br>
+}</td>
+  <td>(optional) Anchor of the icon image. This defaults to the center-bottom of the image.</td>
 </tr>
 </table>

--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -442,6 +442,10 @@ export interface MarkerIcon {
     width?: number;
     height?: number;
   };
+  anchor?: {
+    x?: number;
+    y?: number;
+  };
 }
 
 export interface MarkerOptions {

--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -3310,7 +3310,7 @@ export class Marker extends BaseClass {
   }
 
   /**
-   * Changes the info window anchor. This defaults to 50% from the left of the image and at the bottom of the image.
+   * Changes the icon anchor. This defaults to 50% from the left of the image and at the bottom of the image.
    * @param x {number} Distance from left of the icon image in pixels.
    * @param y {number} Distance from top of the icon image in pixels.
    */
@@ -3318,7 +3318,7 @@ export class Marker extends BaseClass {
   setIconAnchor(x: number, y: number): void {}
 
   /**
-   * Changes the info window anchor. This defaults to 50% from the left of the image and at the top of the image.
+   * Changes the infoWindow anchor. This defaults to 50% from the left of the image and at the top of the image.
    * @param x {number} Distance from left of the icon image in pixels.
    * @param y {number} Distance from top of the icon image in pixels.
    */


### PR DESCRIPTION
The MarkerIcon interface is missing the anchor object. I added it and also improved the docs.

I'm not sure about the anchor object that can be passed directly to a Marker. When doing so this has no result, but calling `marker.setIconAnchor(x, y);` is actually passed through to the icon.  I think the anchor object on the Constructor of Marker might be obsolete?