### PR TITLE
Test additional error states. Speed up the tests.

### DIFF
--- a/src/@ionic-native/plugins/google-maps/__snapshots__/google-map.spec.ts.snap
+++ b/src/@ionic-native/plugins/google-maps/__snapshots__/google-map.spec.ts.snap
@@ -34,17 +34,33 @@ Array [
 `;
 
 exports[`GoogleMap without cordova should display a message in the target element 1`] = `
-"
-        <div class=\\"show-page\\">
-          <div id=\\"testId\\" style=\\"width: 100px; height: 100px; position: relative;\\"><div style=\\"color: red; position: absolute; width: 80%; height: 50%; top: 0px; bottom: 0px; right: 0px; left: 0px; padding: 0px; margin: auto;\\">[GoogleMaps]<br>You need to execute \\"$&gt; ionic cordova run browser\\".<br>\\"$&gt; ionic serve\\" is not supported.</div></div>
-        </div>
-      "
+<div
+  id="testId"
+  style="width: 100px; height: 100px; position: relative;"
+>
+  <div
+    style="color: red; position: absolute; width: 80%; height: 50%; top: 0px; bottom: 0px; right: 0px; left: 0px; padding: 0px; margin: auto;"
+  >
+    [GoogleMaps]
+    <br />
+    You need to execute "$&gt; ionic cordova run browser".
+    <br />
+    "$&gt; ionic serve" is not supported.
+  </div>
+</div>
 `;
 
 exports[`GoogleMap without plugin should display a message in the target element 1`] = `
-"
-        <div class=\\"show-page\\">
-          <div id=\\"testId\\" style=\\"width: 100px; height: 100px; position: relative;\\"><div style=\\"color: red; position: absolute; width: 80%; height: 50%; top: 0px; bottom: 0px; right: 0px; left: 0px; padding: 0px; margin: auto;\\">[GoogleMaps]<br>cordova-plugin-googlemaps is not installed or not ready yet.</div></div>
-        </div>
-      "
+<div
+  id="testId"
+  style="width: 100px; height: 100px; position: relative;"
+>
+  <div
+    style="color: red; position: absolute; width: 80%; height: 50%; top: 0px; bottom: 0px; right: 0px; left: 0px; padding: 0px; margin: auto;"
+  >
+    [GoogleMaps]
+    <br />
+    cordova-plugin-googlemaps is not installed or not ready yet.
+  </div>
+</div>
 `;

--- a/src/@ionic-native/plugins/google-maps/__snapshots__/google-map.spec.ts.snap
+++ b/src/@ionic-native/plugins/google-maps/__snapshots__/google-map.spec.ts.snap
@@ -1,13 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GoogleMap with cordova should throw when the element does not exist 1`] = `[Error: Can not find the element [#uniqueId-0]]`;
+exports[`GoogleMap with cordova should error when the target element does not appear in time with custom timeout 1`] = `[Error: Can not find the element [#testId]]`;
 
-exports[`GoogleMap with cordova should throw when the element is too small 1`] = `[Error: DIV[#uniqueId-1] is too small. Must be bigger than 100x100.]`;
+exports[`GoogleMap with cordova should throw when the element does not exist 1`] = `[Error: Can not find the element [#testId]]`;
+
+exports[`GoogleMap with cordova should throw when the element is too small 1`] = `[Error: DIV[#testId] is too small. Must be bigger than 100x100.]`;
 
 exports[`GoogleMap with cordova should work when the dom element is present and an ID is passed 1`] = `
 Array [
   <div
-    id="uniqueId-2"
+    id="testId"
     style="width: 100px; height: 100px;"
   />,
   undefined,
@@ -16,15 +18,25 @@ Array [
 
 exports[`GoogleMap with cordova should work when the dom element is present and an element is passed 1`] = `
 <div
-  id="uniqueId-3"
+  id="testId"
   style="width: 100px; height: 100px;"
 />
+`;
+
+exports[`GoogleMap with cordova with async DOM modifications should find the target element if it is initially not present in the DOM 1`] = `
+Array [
+  <div
+    id="testId"
+    style="width: 100px; height: 100px;"
+  />,
+  undefined,
+]
 `;
 
 exports[`GoogleMap without cordova should display a message in the target element 1`] = `
 "
         <div class=\\"show-page\\">
-          <div id=\\"uniqueId-4\\" style=\\"width: 100px; height: 100px; position: relative;\\"><div style=\\"color: red; position: absolute; width: 80%; height: 50%; top: 0px; bottom: 0px; right: 0px; left: 0px; padding: 0px; margin: auto;\\">[GoogleMaps]<br>You need to execute \\"$&gt; ionic cordova run browser\\".<br>\\"$&gt; ionic serve\\" is not supported.</div></div>
+          <div id=\\"testId\\" style=\\"width: 100px; height: 100px; position: relative;\\"><div style=\\"color: red; position: absolute; width: 80%; height: 50%; top: 0px; bottom: 0px; right: 0px; left: 0px; padding: 0px; margin: auto;\\">[GoogleMaps]<br>You need to execute \\"$&gt; ionic cordova run browser\\".<br>\\"$&gt; ionic serve\\" is not supported.</div></div>
         </div>
       "
 `;
@@ -32,7 +44,7 @@ exports[`GoogleMap without cordova should display a message in the target elemen
 exports[`GoogleMap without plugin should display a message in the target element 1`] = `
 "
         <div class=\\"show-page\\">
-          <div id=\\"uniqueId-5\\" style=\\"width: 100px; height: 100px; position: relative;\\"><div style=\\"color: red; position: absolute; width: 80%; height: 50%; top: 0px; bottom: 0px; right: 0px; left: 0px; padding: 0px; margin: auto;\\">[GoogleMaps]<br>cordova-plugin-googlemaps is not installed or not ready yet.</div></div>
+          <div id=\\"testId\\" style=\\"width: 100px; height: 100px; position: relative;\\"><div style=\\"color: red; position: absolute; width: 80%; height: 50%; top: 0px; bottom: 0px; right: 0px; left: 0px; padding: 0px; margin: auto;\\">[GoogleMaps]<br>cordova-plugin-googlemaps is not installed or not ready yet.</div></div>
         </div>
       "
 `;

--- a/src/@ionic-native/plugins/google-maps/__snapshots__/google-map.spec.ts.snap
+++ b/src/@ionic-native/plugins/google-maps/__snapshots__/google-map.spec.ts.snap
@@ -1,10 +1,10 @@
-// Jest Snapshot v1, https://jestjs.io/docs/en/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GoogleMap should throw when the element does not exist 1`] = `[Error: Can not find the element [#uniqueId-0]]`;
+exports[`GoogleMap with cordova should throw when the element does not exist 1`] = `[Error: Can not find the element [#uniqueId-0]]`;
 
-exports[`GoogleMap should throw when the element is too small 1`] = `[Error: DIV[#uniqueId-1] is too small. Must be bigger than 100x100.]`;
+exports[`GoogleMap with cordova should throw when the element is too small 1`] = `[Error: DIV[#uniqueId-1] is too small. Must be bigger than 100x100.]`;
 
-exports[`GoogleMap should work when the dom element is present and an ID is passed 1`] = `
+exports[`GoogleMap with cordova should work when the dom element is present and an ID is passed 1`] = `
 Array [
   <div
     id="uniqueId-2"
@@ -14,9 +14,25 @@ Array [
 ]
 `;
 
-exports[`GoogleMap should work when the dom element is present and an element is passed 1`] = `
+exports[`GoogleMap with cordova should work when the dom element is present and an element is passed 1`] = `
 <div
   id="uniqueId-3"
   style="width: 100px; height: 100px;"
 />
+`;
+
+exports[`GoogleMap without cordova should display a message in the target element 1`] = `
+"
+        <div class=\\"show-page\\">
+          <div id=\\"uniqueId-4\\" style=\\"width: 100px; height: 100px; position: relative;\\"><div style=\\"color: red; position: absolute; width: 80%; height: 50%; top: 0px; bottom: 0px; right: 0px; left: 0px; padding: 0px; margin: auto;\\">[GoogleMaps]<br>You need to execute \\"$&gt; ionic cordova run browser\\".<br>\\"$&gt; ionic serve\\" is not supported.</div></div>
+        </div>
+      "
+`;
+
+exports[`GoogleMap without plugin should display a message in the target element 1`] = `
+"
+        <div class=\\"show-page\\">
+          <div id=\\"uniqueId-5\\" style=\\"width: 100px; height: 100px; position: relative;\\"><div style=\\"color: red; position: absolute; width: 80%; height: 50%; top: 0px; bottom: 0px; right: 0px; left: 0px; padding: 0px; margin: auto;\\">[GoogleMaps]<br>cordova-plugin-googlemaps is not installed or not ready yet.</div></div>
+        </div>
+      "
 `;

--- a/src/@ionic-native/plugins/google-maps/google-map.spec.ts
+++ b/src/@ionic-native/plugins/google-maps/google-map.spec.ts
@@ -37,7 +37,7 @@ describe('GoogleMap', () => {
           </div>
         `;
 
-        const _ = new GoogleMap(mapId, undefined, 100);
+        const _ = new GoogleMap(mapId, undefined, 0);
         const [promise] = googleMap.getMap.mock.calls[0];
         expect(googleMap.getMap).toHaveBeenCalled();
         await expect(promise).rejects.toMatchSnapshot();
@@ -53,7 +53,7 @@ describe('GoogleMap', () => {
         </div>
       `;
 
-      const _ = new GoogleMap(mapId, undefined, 100);
+      const _ = new GoogleMap(mapId, undefined, 0);
       const [promise] = googleMap.getMap.mock.calls[0];
       expect(googleMap.getMap).toHaveBeenCalled();
       await expect(promise).resolves.toMatchSnapshot();
@@ -89,7 +89,7 @@ describe('GoogleMap', () => {
         </div>
       `;
 
-      const _ = new GoogleMap(mapId, undefined, 100);
+      const _ = new GoogleMap(mapId, undefined, 0);
       expect(document.body.innerHTML).toMatchSnapshot();
     });
   });
@@ -106,7 +106,7 @@ describe('GoogleMap', () => {
         </div>
       `;
 
-      const _ = new GoogleMap(mapId, undefined, 100);
+      const _ = new GoogleMap(mapId, undefined, 0);
       expect(document.body.innerHTML).toMatchSnapshot();
     });
   });

--- a/src/@ionic-native/plugins/google-maps/google-map.spec.ts
+++ b/src/@ionic-native/plugins/google-maps/google-map.spec.ts
@@ -21,10 +21,6 @@ describe('GoogleMap', () => {
       });
     });
 
-    /**
-     * TODO: Find a clean way to configure the timeout when searching
-     * for an element so that we can error more quickly
-     */
     describe('should throw', () => {
       it('when the element does not exist', async () => {
         const _ = new GoogleMap(nextId());
@@ -41,7 +37,7 @@ describe('GoogleMap', () => {
           </div>
         `;
 
-        const _ = new GoogleMap(mapId);
+        const _ = new GoogleMap(mapId, undefined, 100);
         const [promise] = googleMap.getMap.mock.calls[0];
         expect(googleMap.getMap).toHaveBeenCalled();
         await expect(promise).rejects.toMatchSnapshot();
@@ -57,7 +53,7 @@ describe('GoogleMap', () => {
         </div>
       `;
 
-      const _ = new GoogleMap(mapId);
+      const _ = new GoogleMap(mapId, undefined, 100);
       const [promise] = googleMap.getMap.mock.calls[0];
       expect(googleMap.getMap).toHaveBeenCalled();
       await expect(promise).resolves.toMatchSnapshot();
@@ -93,7 +89,7 @@ describe('GoogleMap', () => {
         </div>
       `;
 
-      const _ = new GoogleMap(mapId);
+      const _ = new GoogleMap(mapId, undefined, 100);
       expect(document.body.innerHTML).toMatchSnapshot();
     });
   });
@@ -110,7 +106,7 @@ describe('GoogleMap', () => {
         </div>
       `;
 
-      const _ = new GoogleMap(mapId);
+      const _ = new GoogleMap(mapId, undefined, 100);
       expect(document.body.innerHTML).toMatchSnapshot();
     });
   });

--- a/src/@ionic-native/plugins/google-maps/google-map.spec.ts
+++ b/src/@ionic-native/plugins/google-maps/google-map.spec.ts
@@ -1,10 +1,12 @@
 import { GoogleMap } from '../../../../dist/@ionic-native/plugins/google-maps';
 
 import { GoogleMapCordovaMock, GoogleMapsCordovaMock } from '../../../test/mocks';
-import { mockCordova, nextId } from '../../../test/utils';
+import { mockCordova, mockCordovaRestore, nextId } from '../../../test/utils';
 
 
 describe('GoogleMap', () => {
+  afterEach(mockCordovaRestore);
+
   describe('with cordova', () => {
     let googleMaps: GoogleMapsCordovaMock;
     let googleMap: GoogleMapCordovaMock;
@@ -17,11 +19,6 @@ describe('GoogleMap', () => {
         GoogleMaps: googleMaps,
         Map: googleMap,
       });
-    });
-
-    afterEach(() => {
-      (window as any).plugin = {};
-      (window as any).cordova = null;
     });
 
     /**
@@ -86,6 +83,7 @@ describe('GoogleMap', () => {
 
   describe('without cordova', () => {
     beforeEach(() => window.cordova = null);
+
     it('should display a message in the target element', async () => {
       const mapId = nextId();
 

--- a/src/@ionic-native/plugins/google-maps/google-map.spec.ts
+++ b/src/@ionic-native/plugins/google-maps/google-map.spec.ts
@@ -1,10 +1,11 @@
 import { GoogleMap } from '../../../../dist/@ionic-native/plugins/google-maps';
 
 import { GoogleMapCordovaMock, GoogleMapsCordovaMock } from '../../../test/mocks';
-import { mockCordova, mockCordovaRestore, nextId } from '../../../test/utils';
+import { mockCordova, mockCordovaRestore } from '../../../test/utils';
 
 
 describe('GoogleMap', () => {
+  beforeEach(() => document.body.innerHTML = '');
   afterEach(mockCordovaRestore);
 
   describe('with cordova', () => {
@@ -23,13 +24,13 @@ describe('GoogleMap', () => {
 
     describe('should throw', () => {
       it('when the element does not exist', async () => {
-        const _ = new GoogleMap(nextId());
+        const _ = new GoogleMap('testId', null, 0);
         const [promise] = googleMap.getMap.mock.calls[0];
         await expect(promise).rejects.toMatchSnapshot();
       });
 
       it('when the element is too small', async () => {
-        const mapId = nextId();
+        const mapId = 'testId';
 
         document.body.innerHTML = `
           <div class="show-page">
@@ -45,7 +46,7 @@ describe('GoogleMap', () => {
     });
 
     it('should work when the dom element is present and an ID is passed', async () => {
-      const mapId = nextId();
+      const mapId = 'testId';
 
       document.body.innerHTML = `
         <div class="show-page">
@@ -60,7 +61,7 @@ describe('GoogleMap', () => {
     });
 
     it('should work when the dom element is present and an element is passed', async () => {
-      const mapId = nextId();
+      const mapId = 'testId';
 
       document.body.innerHTML = `
         <div class="show-page">
@@ -75,13 +76,51 @@ describe('GoogleMap', () => {
       expect(googleMap.getMap).toHaveBeenCalled();
       await expect(mapEl).toMatchSnapshot();
     });
+
+    describe('with async DOM modifications', () => {
+      it('should find the target element if it is initially not present in the DOM', async () => {
+        const mapId = 'testId';
+
+        const _ = new GoogleMap(mapId);
+
+        setTimeout(() => {
+          document.body.innerHTML = `
+            <div class="show-page">
+              <div id="${mapId}" style="width: 100px; height: 100px;"></div>
+            </div>
+          `;
+        }, 250);
+
+        const [mapEl] = googleMap.getMap.mock.calls[0];
+        expect(googleMap.getMap).toHaveBeenCalled();
+        await expect(mapEl).resolves.toMatchSnapshot();
+      });
+    });
+
+    it('should error when the target element does not appear in time with custom timeout', async () => {
+      const mapId = 'testId';
+
+      const _ = new GoogleMap(mapId, null, 100);
+
+      setTimeout(() => {
+        document.body.innerHTML = `
+          <div class="show-page">
+            <div id="${mapId}" style="width: 100px; height: 100px;"></div>
+          </div>
+        `;
+      }, 300);
+
+      const [mapEl] = googleMap.getMap.mock.calls[0];
+      expect(googleMap.getMap).toHaveBeenCalled();
+      await expect(mapEl).rejects.toMatchSnapshot();
+    });
   });
 
   describe('without cordova', () => {
     beforeEach(() => window.cordova = null);
 
     it('should display a message in the target element', async () => {
-      const mapId = nextId();
+      const mapId = 'testId';
 
       document.body.innerHTML = `
         <div class="show-page">
@@ -98,7 +137,7 @@ describe('GoogleMap', () => {
     beforeEach(() => (window as any).cordova = {});
 
     it('should display a message in the target element', async () => {
-      const mapId = nextId();
+      const mapId = 'testId';
 
       document.body.innerHTML = `
         <div class="show-page">

--- a/src/@ionic-native/plugins/google-maps/google-map.spec.ts
+++ b/src/@ionic-native/plugins/google-maps/google-map.spec.ts
@@ -129,7 +129,7 @@ describe('GoogleMap', () => {
       `;
 
       const _ = new GoogleMap(mapId, undefined, 0);
-      expect(document.body.innerHTML).toMatchSnapshot();
+      expect(document.getElementById(mapId)).toMatchSnapshot();
     });
   });
 
@@ -146,7 +146,7 @@ describe('GoogleMap', () => {
       `;
 
       const _ = new GoogleMap(mapId, undefined, 0);
-      expect(document.body.innerHTML).toMatchSnapshot();
+      expect(document.getElementById(mapId)).toMatchSnapshot();
     });
   });
 });

--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -2716,7 +2716,7 @@ export class StreetViewPanorama extends BaseClass {
   plugin: 'cordova-plugin-googlemaps'
 })
 export class GoogleMap extends BaseClass {
-  constructor(element: HTMLElement | string, options?: GoogleMapOptions) {
+  constructor(element: HTMLElement | string, options?: GoogleMapOptions, elFindTimeout = 2000) {
     if (checkAvailability(GoogleMaps.getPluginRef(), null, GoogleMaps.getPluginName()) === true) {
       // ---------------
       // Create a map
@@ -2733,12 +2733,13 @@ export class GoogleMap extends BaseClass {
       } else if (typeof element === 'string') {
 
         super(GoogleMaps.getPlugin().Map.getMap(getPromise<any[]>((resolve, reject) => {
-          let count: number;
-          let i: number;
-          count = 0;
+          let numAttempts = 0;
+          const durationBetweenAttemptsMs = 100;
+          const maxAttempts = Math.floor(elFindTimeout / durationBetweenAttemptsMs);
+
           const timer: any = setInterval(() => {
             let targets: any[];
-            for (i = 0; i < TARGET_ELEMENT_FINDING_QUERYS.length; i++) {
+            for (let i = 0; i < TARGET_ELEMENT_FINDING_QUERYS.length; i++) {
               targets = Array.from(document.querySelectorAll(TARGET_ELEMENT_FINDING_QUERYS[i] + element))
                 // Filter out el which are already map layers
                 .filter((target) => {
@@ -2751,7 +2752,7 @@ export class GoogleMap extends BaseClass {
                 return;
               }
             }
-            if (count++ < 20) {
+            if (numAttempts++ < maxAttempts) {
               return;
             }
             clearInterval(timer);
@@ -2761,7 +2762,7 @@ export class GoogleMap extends BaseClass {
             } else {
               reject(new Error('Can not find the element [#' + element + ']'));
             }
-          }, 100);
+          }, durationBetweenAttemptsMs);
         }), options));
 
       } else if (element === null && options) {

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,5 +1,7 @@
 import { BaseArrayClass, BaseClass } from './cordova-plugin-google-maps-proxy';
 
+const untypedWindow: any = window;
+
 /**
  * Use when you need a sequential id in tests
  * Should be needed rarely
@@ -18,11 +20,11 @@ export const nextId = (() => {
  * @param plugins a map of plugins to mock
  */
 export const mockCordova = (plugins: {}) => {
-  (window as any).cordova = {
+  untypedWindow.cordova = {
 
   };
 
-  (window as any).plugin = {
+  untypedWindow.plugin = {
     google: {
       maps: {
         BaseArrayClass,
@@ -32,4 +34,13 @@ export const mockCordova = (plugins: {}) => {
       }
     }
   };
+};
+
+
+/**
+ * Undoes window patching performed by `mockCordova`
+ */
+export const mockCordovaRestore = () => {
+  untypedWindow.cordova = null;
+  untypedWindow.plugin = null;
 };


### PR DESCRIPTION
Added a `mockCordovaRestore` function to be used in the `afterEach` when cordova or plugins are mocked.

Added a optional constructor parameter called `elFindTimeout` so that the time searching for an element can be changed. Useful for testing error states. Improved test time by 33% but would have greater impact with more tests as previously each test of error state took at least the length of the timeout of 2000ms.

Open to other ideas of achieving this if the proposed solution is not desired.