### PR TITLE
Fix typo

### DIFF
--- a/documents/googlemap/README.md
+++ b/documents/googlemap/README.md
@@ -399,7 +399,7 @@ Before using this plugin, please understand how this plugin work.
     </tr>
     <tr>
       <td>options</td>
-      <td><a href="../polylineoptions/README.md">PollineOptions</a></td>
+      <td><a href="../polylineoptions/README.md">PolylineOptions</a></td>
       <td>options</td>
     </tr>
     </table>


### PR DESCRIPTION
Fix a trivial typo `PollineOptions` instead of `PolylineOptions`