### PR TITLE
Fix `Map.setDiv` with an HTMLElement

### DIFF
--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -3223,7 +3223,7 @@ export class GoogleMap extends BaseClass {
       });
     } else {
       if (domNode instanceof HTMLElement &&
-          !domNode.offsetParent &&
+          domNode.offsetParent &&
           domNode.offsetWidth >= 100 && domNode.offsetHeight >= 100) {
         return this._objectInstance.setDiv(domNode);
       } else {


### PR DESCRIPTION
Currently the `setDiv` method always fails if it is performed on an element which belongs to the document body, because of an inverted check.

The check can be trivially fixed. Should we also handle explicitly the case in which there is no `offsetParent` (as in the `Map` constructor?)